### PR TITLE
Update background color of community tab for darkmode

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -41,7 +41,7 @@ flowchart LR
     %% archive-- revived -->incubator
 
     %% style
-    classDef community fill:#ffffff,stroke:#114226,stroke-width:2,stroke-dasharray: 5 5
+    classDef community fill:#fff,stroke:#24292f,stroke-width:2,stroke-dasharray: 5 5
     classDef github fill:#24292f,stroke:none,color:#fff
 ```
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -41,7 +41,7 @@ flowchart LR
     %% archive-- revived -->incubator
 
     %% style
-    classDef community fill:#a5e8c1,stroke:#114226,stroke-width:2,stroke-dasharray: 5 5
+    classDef community fill:#ffffff,stroke:#114226,stroke-width:2,stroke-dasharray: 5 5
     classDef github fill:#24292f,stroke:none,color:#fff
 ```
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This fixes the unfortunate issue with the green background color when in darkmode.

<img width="901" alt="CleanShot 2022-11-21 at 20 10 33@2x" src="https://user-images.githubusercontent.com/1610/203139415-777a5c0f-8179-4817-98be-1806d081343b.png">

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda-incubator/governance/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: ../blob/main/CONTRIBUTING.md -->
